### PR TITLE
feat: Kafka 프로덕션 준비를 위한 구조 개선 및 문서화

### DIFF
--- a/docs/kafka-basics.md
+++ b/docs/kafka-basics.md
@@ -38,6 +38,16 @@ Apache Kafka는 실시간 스트리밍 데이터를 위한 **분산 이벤트 �
 브로커-3: order-completed-partition-2 (Leader)
 ```
 
+**리더-팔로워 관계와 ISR(In-Sync Replica)**:
+
+- **Leader Replica**: 해당 파티션의 읽기/쓰기 요청을 실제로 처리하는 브로커
+- **Follower Replica**: Leader로부터 데이터를 복제받아 저장하는 브로커
+  - 평소에는 클라이언트 읽기 요청에 관여하지 않음
+  - 하지만 `acks` 설정에 따라 **쓰기 요청 응답에는 관여**할 수 있음
+- **ISR(In-Sync Replica)**: Leader와 동기화 상태를 유지하는 Replica들
+  - `acks=all` 설정 시 ISR에 속한 모든 Replica가 메시지를 받아야 Producer에게 응답
+  - Follower가 지연되면 ISR에서 제외되고, 복구되면 다시 ISR에 포함
+
 ### 2.2 Topic (토픽)
 
 **역할**: 메시지를 분류하는 논리적 카테고리 (데이터베이스의 테이블과 유사)
@@ -498,6 +508,11 @@ kafka:
       retries: 3 # 재시도 횟수
       acks: all # 모든 복제본 확인 후 응답
 ```
+
+**Producer Idempotence 설정**:
+- `enable.idempotence=true`: 네트워크 장애 등으로 동일한 메시지가 중복 발행되는 것을 방지
+- Producer가 내부적으로 시퀀스 번호를 관리하여 브로커에서 중복 메시지 제거
+- `acks=all`과 함께 사용하여 at-least-once 보장하면서 중복 방지
 
 ### 6.2 Consumer 설정
 

--- a/src/main/java/kr/hhplus/be/server/common/config/KafkaTopics.java
+++ b/src/main/java/kr/hhplus/be/server/common/config/KafkaTopics.java
@@ -1,0 +1,63 @@
+package kr.hhplus.be.server.common.config;
+
+/**
+ * Kafka 토픽 이름 상수 관리 클래스
+ *
+ * 피드백 반영: "coupon-issued"와 같은 토픽 이름은 공통된 상수로 관리
+ *
+ * 효과:
+ * - 토픽 이름 변경 시 한 곳에서만 수정
+ * - 오타 방지 및 컴파일 타임 체크
+ * - IDE 자동 완성 지원
+ */
+public final class KafkaTopics {
+
+    private KafkaTopics() {
+        // 인스턴스 생성 방지
+    }
+
+    /**
+     * 주문 관련 토픽
+     */
+    public static final String ORDER_COMPLETED = "order-completed";
+
+    /**
+     * 쿠폰 관련 토픽
+     */
+    public static final String COUPON_ISSUE = "coupon-issue";
+
+    /**
+     * 사용자 활동 관련 토픽
+     */
+    public static final String USER_ACTIVITY = "user-activity";
+
+    /**
+     * 잔액 관련 토픽
+     */
+    public static final String BALANCE_ACTIVITY = "balance-activity";
+
+    /**
+     * 상품 관련 토픽
+     */
+    public static final String PRODUCT_ACTIVITY = "product-activity";
+
+    /**
+     * 일반 이벤트 토픽 (기본값)
+     */
+    public static final String GENERAL_EVENTS = "general-events";
+
+    /**
+     * Consumer Group 이름들
+     */
+    public static final class ConsumerGroups {
+
+        private ConsumerGroups() {
+            // 인스턴스 생성 방지
+        }
+
+        public static final String DATA_PLATFORM_CONSUMER_GROUP = "data-platform-consumer-group";
+        public static final String COUPON_ISSUE_CONSUMER_GROUP = "coupon-issue-consumer-group";
+        public static final String ORDER_ANALYTICS_GROUP = "order-analytics-group";
+        public static final String NOTIFICATION_GROUP = "notification-group";
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/coupon/consumer/CouponIssueConsumer.java
+++ b/src/main/java/kr/hhplus/be/server/coupon/consumer/CouponIssueConsumer.java
@@ -36,7 +36,7 @@ public class CouponIssueConsumer {
      * - 쿠폰ID를 키로 사용하여 동일 쿠폰은 같은 파티션으로
      * - 단일 쿠폰의 순서 보장 (선착순 보장)
      */
-    @KafkaListener(topics = "coupon-issue", groupId = "coupon-issue-consumer-group")
+    @KafkaListener(topics = "${kafka.topics.coupon-issue}", groupId = "${kafka.consumer-groups.coupon-issue}", concurrency = "${app.kafka.listeners.coupon-issue.concurrency:3}")
     @Transactional
     public void handleCouponIssue(
             @Payload CouponIssueEvent event,
@@ -84,8 +84,8 @@ public class CouponIssueConsumer {
     /**
      * 중복 발급 체크 (멱등성 보장)
      * 
-     * 종범 멘토 권장: 쿠폰ID + 유저ID로 중복 방지
-     * "이미 발급받은 사용자면 '있어'라고 단순 응답"
+     * 쿠폰ID + 유저ID로 중복 방지
+     * 이미 발급받은 사용자면 '있어'라고 단순 응답
      */
     private boolean isAlreadyIssued(Long couponId, Long userId) {
         return userCouponRepository.existsByUserIdAndCouponId(userId, couponId);
@@ -94,7 +94,7 @@ public class CouponIssueConsumer {
     /**
      * Consumer 성능 모니터링 로그
      * 
-     * 로이 멘토 강조: "Consumer Lag 모니터링 필수"
+     * "Consumer Lag 모니터링 필수"
      */
     private void logProcessingMetrics(CouponIssueEvent event, int partition, long offset) {
         long processingDelay = System.currentTimeMillis() -

--- a/src/main/java/kr/hhplus/be/server/external/DataPlatformConsumer.java
+++ b/src/main/java/kr/hhplus/be/server/external/DataPlatformConsumer.java
@@ -23,12 +23,11 @@ public class DataPlatformConsumer {
     /**
      * 주문 완료 이벤트 처리
      * 
-     * 멘토링 핵심 원칙:
      * - Consumer는 반드시 멱등성을 보장해야 함
      * - 처리 실패 시 자동 재시도 (Spring Kafka 기본 설정)
      * - 비즈니스 로직은 최대한 단순하게 유지
      */
-    @KafkaListener(topics = "order-completed", groupId = "data-platform-consumer-group")
+    @KafkaListener(topics = "${kafka.topics.order-completed}", groupId = "${kafka.consumer-groups.data-platform}", concurrency = "${app.kafka.listeners.data-platform.concurrency:3}")
     public void handleOrderCompleted(
             @Payload OrderDataPlatformEvent event,
             @Header(name = KafkaHeaders.RECEIVED_KEY) String key,

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -62,6 +62,21 @@ app:
       time-to-live: 1800000 # 30분
       key-prefix: "ecommerce::"
 
+# Kafka 토픽 및 Consumer Group 설정
+kafka:
+  topics:
+    order-completed: "order-completed"
+    coupon-issue: "coupon-issue"
+    user-activity: "user-activity"
+    balance-activity: "balance-activity"
+    product-activity: "product-activity"
+    general-events: "general-events"
+  consumer-groups:
+    data-platform: "data-platform-consumer-group"
+    coupon-issue: "coupon-issue-consumer-group"
+    order-analytics: "order-analytics-group"
+    notification: "notification-group"
+
   kafka:
     bootstrap-servers: localhost:9092
     producer:
@@ -87,6 +102,16 @@ app:
         fetch.max.bytes: 52428800 # 최대 fetch 크기 (50MB)
         fetch.max.wait.ms: 500 # fetch 대기 시간
         max.poll.records: 500 # 한 번에 poll할 최대 레코드 수
+    # Consumer 설정을 외부화 (피드백 반영)
+    listeners:
+      data-platform:
+        topics: "${kafka.topics.order-completed:order-completed}"
+        group-id: "${kafka.consumer-groups.data-platform:data-platform-consumer-group}"
+        concurrency: 3
+      coupon-issue:
+        topics: "${kafka.topics.coupon-issue:coupon-issue}"
+        group-id: "${kafka.consumer-groups.coupon-issue:coupon-issue-consumer-group}"
+        concurrency: 3
 
 springdoc:
   api-docs:


### PR DESCRIPTION
- 토픽명 중앙 관리: KafkaTopics 상수 클래스 추가
- 발송 보장 강화: 동기/비동기 전송 로직 분리 및 결과 처리 개선
- 설정 외부화: KafkaListener를 SpEL로 application.yml 설정 적용
- Consumer 동시성 제어: concurrency 설정 추가로 처리량 향상
- Kafka 기초 문서 업데이트: 구현 개선사항 반영

주요 개선사항:
• KafkaTemplate.send()의 CompletableFuture 기반 결과 처리 • 토픽명 하드코딩 제거 및 컴파일타임 검증 강화
• Consumer Group과 토픽 설정의 중앙 집중 관리
• 파티션/오프셋 정보를 포함한 상세 로깅